### PR TITLE
Add support for ROS_ALLOWED_TOPICS_CONFIG environment variable in configuration loading

### DIFF
--- a/src/desert_classes/TopicsConfig.cpp
+++ b/src/desert_classes/TopicsConfig.cpp
@@ -5,23 +5,36 @@ std::map<uint8_t, std::string> TopicsConfig::_identifiers_list;
 
 void TopicsConfig::load_configuration()
 {
-  std::ifstream ifs("ros_allowed_topics.conf");
-  
+  const char* env_path = std::getenv("ROS_ALLOWED_TOPICS_CONFIG");
+
+  std::string config_path;
+
+  if (env_path != nullptr)
+  {
+    config_path = env_path;
+  }
+  else
+  {
+    config_path = "ros_allowed_topics.conf";
+  }
+
+  std::ifstream ifs(config_path);
+
   if (!ifs.good())
   {
-    printf("CRITICAL: a file called 'ros_allowed_topics.conf' must be present in the current directory\n");
+    printf("CRITICAL: configuration file '%s' could not be opened\n", config_path.c_str());
   }
-  
+
   json config = json::parse(ifs);
 
   // Find object and convert to map
   std::map<std::string, uint8_t> topics = config.at("topics").get<std::map<std::string, uint8_t>>();
-  
+
   std::map<uint8_t, std::string> identifiers;
-  
+
   for (std::map<std::string, uint8_t>::iterator i = topics.begin(); i != topics.end(); ++i)
     identifiers[i->second] = i->first;
-  
+
   _topics_list = topics;
   _identifiers_list = identifiers;
 }

--- a/src/desert_classes/TopicsConfig.h
+++ b/src/desert_classes/TopicsConfig.h
@@ -38,6 +38,7 @@
 #include <string>
 #include <cstdint>
 #include <fstream>
+#include <cstdlib>
 
 /** @endcond */
 
@@ -52,7 +53,9 @@ class TopicsConfig
    /**
     * @brief Initialize the configuration
     *
-    * This function reads the configuration file from ./ros_allowed_topics.conf. 
+    * This function reads the configuration file from:
+    * env variable: ROS_ALLOWED_TOPICS_CONFIG
+    * or from: ./ros_allowed_topics.conf. 
     * If not present, a warning will be displayed.
     */
     static void load_configuration();


### PR DESCRIPTION
This pull request updates the load_configuration() function to allow reading the ROS2 allowed topics configuration from an environment variable, in addition to the existing default file.
Checks the environment variable ROS_ALLOWED_TOPICS_CONFIG first and if not set falls back to ./ros_allowed_topics.conf 

Example:
```bash
export ROS_ALLOWED_TOPICS_CONFIG="/path/to/custom/ros_allowed_topics.conf"
```
